### PR TITLE
Allow full URLs for local development

### DIFF
--- a/frontend/src/controls/UserDialog.tsx
+++ b/frontend/src/controls/UserDialog.tsx
@@ -73,7 +73,8 @@ class UserDialog extends React.Component<Props & WithStyles<typeof styles>, Stat
         this.props.onUserAdded({name: this.state.name, avatar: this.state.avatar, online: true} as User);
     }
     handleConnect = () => {
-        this.props.store.api.setHostname("https://"+this.state.hostname);
+        const hostname = !/^https?\:\/\//.test(this.state.hostname) ? "https://"+this.state.hostname : this.state.hostname;
+        this.props.store.api.setHostname(hostname);
         window.localStorage.setItem("hostname", this.state.hostname);
         this.props.store.api.getCart({name: "test", avatar: "test", online: true} as User).then( (x) =>{
             this.setState({connected:true});


### PR DESCRIPTION
If the host given in the connect dialog already has `http://` or `https://` protocol, just use it as is, otherwise add `https://` as before. Allows entering `http://localhost:1234` when running a service or CORS proxy locally.